### PR TITLE
fix grammar

### DIFF
--- a/api.js
+++ b/api.js
@@ -26,7 +26,7 @@ api.get('/:param', (req, res) => {
 api.get('/', (req, res) => {
   res.send(
     `
-Put something after the / to get reverse it \n
+Put something after the / to reverse it \n
 🔃
 github.com/joshkmartinez/reverse
     `


### PR DESCRIPTION
This fix addresses a grammar mistake that occurs inside of the Response text that is sent to the user when they request the root route (homepage).